### PR TITLE
Adds qubes-specific things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+install:
+	pipenv install
+	cp qubes/securedrop.Proxy /etc/qubes-rpc/securedrop.Proxy
+
+test:
+	pipenv run python -m unittest -v

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ First, determine which of your VMs will be acting as the proxy VM
 (where this code will be running), and which will be acting as the
 client VM (where the client code will be running). For the purposes of
 this documentation, we assume the client is running in
-`securedrop-client`, and the proxy is running in `seuredrop-proxy`.
+`securedrop-client`, and the proxy is running in `securedrop-proxy`.
 
 Edit `qubes/securedrop.Proxy` to reflect the path to `entrypoint.sh`
 in this repo. Run `make install`, which will move `securedrop.Proxy`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /home/user/projects/securedrop-proxy
+pipenv run ./sd-proxy.py ./config.yaml

--- a/qubes/securedrop.Proxy
+++ b/qubes/securedrop.Proxy
@@ -1,0 +1,1 @@
+/home/user/projects/securedrop-proxy/entrypoint.sh

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,102 @@
+from io import StringIO
+import json
+import subprocess
+import sys
+import unittest
+import uuid
+
+from securedrop_proxy import config
+from securedrop_proxy import main
+from securedrop_proxy import proxy
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.conf = config.Conf()
+        self.conf.host = 'jsonplaceholder.typicode.com'
+        self.conf.scheme = 'https'
+        self.conf.port = 443
+        self.conf.dev = True
+
+    def test_json_response(self):
+        test_input_json = """{ "method": "GET",
+                            "path_query": "/posts?userId=1" }"""
+
+        req = proxy.Req()
+        req.method = 'GET'
+        req.path_query = ''
+        req.headers = {'Accept': 'application/json'}
+
+        # Use custom callbacks
+        def on_save(res, fh, conf):
+            pass
+
+        def on_done(res):
+            res = res.__dict__
+            self.assertEqual(res['status'], 200)
+
+        self.p = proxy.Proxy(self.conf, req, on_save)
+        self.p.on_done = on_done
+        self.p.proxy()
+
+        saved_stdout = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            main.__main__(test_input_json, self.p)
+            output = out.getvalue().strip()
+        finally:
+            sys.stdout = saved_stdout
+
+        response = json.loads(output)
+        for item in json.loads(response['body']):
+            self.assertEqual(item['userId'], 1)
+
+    def test_non_json_response(self):
+        test_input_json = """{ "method": "GET",
+                               "path_query": "" }"""
+
+        def on_save(fh, res, conf):
+            self.fn = str(uuid.uuid4())
+
+            subprocess.run(["cp", fh.name, "/tmp/{}".format(self.fn)])
+
+            res.headers['X-Origin-Content-Type'] = res.headers['Content-Type']
+            res.headers['Content-Type'] = 'application/json'
+            res.body = json.dumps({'filename': self.fn})
+
+        self.p = proxy.Proxy(self.conf, proxy.Req(), on_save)
+        self.p.proxy()
+
+        saved_stdout = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            main.__main__(test_input_json, self.p)
+            output = out.getvalue().strip()
+        finally:
+            sys.stdout = saved_stdout
+
+        response = json.loads(output)
+        self.assertEqual(response['status'], 200)
+
+        # The proxy should have created a filename in the response body
+        self.assertIn('filename', response['body'])
+
+    def test_error_response(self):
+        test_input_json = """"foo": "bar", "baz": "bliff" }"""
+
+        def on_save(fh, res, conf):
+            pass
+
+        def on_done(res):
+            res = res.__dict__
+            self.assertEqual(res['status'], 400)
+            sys.exit(1)
+
+        self.p = proxy.Proxy(self.conf, proxy.Req(), on_save)
+        self.p.on_done = on_done
+
+        with self.assertRaises(SystemExit):
+            self.p.proxy()
+            main.__main__(test_input_json, self.p)


### PR DESCRIPTION
This adds some bits which get scattered around the proxy VM to enable the the proxy script to be run as a qubes-rpc service, and documents the various configuration steps which need to be taken on the proxy VM and `dom0` to demonstrate using the proxy from a different VM.

For the time being, this is little more than a proof-of-concept and prototype (but it should at least unblock further client development). We need to determine how we want to package and install this (and other Python-based) software on the various VMs, which controls how the proxy script will be executed. Once we know that, we can configure the RPC mechanism to run the proxy that way.

