### PR TITLE
securedrop-proxy 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-proxy",
-    version="0.1.0",
+    version="0.1.1",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="SecureDrop Qubes proxy service",


### PR DESCRIPTION
bumping versions after updating requests (see #15), debs built and already on the qubes workstation apt server: https://apt-test-qubes.freedom.press/pool/main/s/securedrop-proxy/