### PR TITLE
Pin library versions in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,10 +7,10 @@ verify_ssl = true
 python_version = "3.5"
 
 [packages]
-furl = "*"
-pyyaml = "*"
-requests = "*"
-werkzeug = "*"
+furl = "==2.0.0"
+pyyaml = "==3.13"
+requests = "==2.20.0"
+werkzeug = "==0.14.1"
 
 [dev-packages]
-vcrpy = "*"
+vcrpy = "==2.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "58ba4d066d275717a5b571cfe5195a63f95cbfec1b2a12d1ba40ecfcb6d00c6d"
+            "sha256": "86be16c12e06dc67fd9e95334532a13dec41da47cee17103e2ee74de62d00ed1"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
This will ensure pipenv lock command does not update package
versions unless explicitly specified in the Pipfile. Since we have automatic
security checks for vulnerabilities in python libraries, this will ensure more
consistency when building and testing our packages, and avoid drift in our requirements.txt and Pipfile.lock files.