### PR TITLE
Remove now unnecessary requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-idna==2.7
-multidict==4.4.2 ; python_version >= '3.4.1'
-pyyaml==3.13
-six==1.11.0
-vcrpy==2.0.1
-wrapt==1.10.11
-yarl==1.2.6 ; python_version >= '3.4'


### PR DESCRIPTION
requirements*.txt files are only used at build time.

Since development requirements are not needed at build time,
this file should not clutter up the repository.

See discussion in https://github.com/freedomofpress/securedrop-debian-packaging/pull/23#discussion_r233591596