### PR TITLE
[wip] update pip mirror update policy, build deb package on each PR to verify policy is adhered to

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,34 @@ version: 2
 jobs:
   build:
     docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+
+      - run:
+          name: Install Debian packaging dependencies and download wheels
+          command: |
+            mkdir ~/packaging && cd ~/packaging
+            git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
+            cd securedrop-debian-packaging
+            make install-deps && make fetch-wheels
+      - run:
+          name: Tag and make source tarball
+          command: |
+            cd ~/project
+            git tag 1000.0  # Dummy version number, doesn't matter what we put here
+            python3 setup.py sdist
+
+      - run:
+          name: Build debian package
+          command: |
+            cd ~/packaging/securedrop-debian-packaging
+            export PKG_VERSION=1000.0
+            export PKG_PATH=~/packaging/securedrop-proxy/dist/securedrop-proxy-$PKG_VERSION.tar.gz
+            make securedrop-proxy
+
+  test:
+    docker:
       - image: circleci/python:3.5
     steps:
       - checkout
@@ -20,3 +48,10 @@ jobs:
             set -e
             source .venv/bin/activate
             make safety
+
+workflows:
+  version: 2
+  securedrop_proxy_ci:
+    jobs:
+      - test
+      - build

--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ pip install --require-hashes -r dev-requirements.txt
 
 #### Update dependencies
 
-To add or update a dependency, modify either `dev-requirements.in` and `requirements.in` and then run `make update-pip-dependencies`. This will generate `dev-requirements.txt` and `requirements.txt`.
+If you're adding or updating a dependency, you need to:
 
-**IMPORTANT:** Do not modify `build-requirements.txt` during normal development. We use a pip mirror for our build process and the hashes in that file point to wheels on our mirror.
+1. Modify either `dev-requirements.in` and `requirements.in` (depending on whether it is prod or dev only) and then run `make update-pip-dependencies`. This will generate `dev-requirements.txt` and `requirements.txt`.
+
+2. For building a debian package from this project, we use the requirements in
+`build-requirements.txt` which uses our pip mirror, i.e. the hashes in that file point to
+wheels on our pip mirror. A maintainer will need to add
+the updated dependency to our pip mirror (you can request this in the PR).
+
+3. Once the pip mirror is updated, you should checkout the [securedrop-debian-packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.
 
 #### configuration
 


### PR DESCRIPTION
# Description

Changes in this repo for https://github.com/freedomofpress/securedrop-debian-packaging/issues/48

# Test Plan

CI/dev only so read the diff, make sure all makes sense, and make sure CI passes

Note that we'll need to modify the required checks for merge for the new job and renamed job, will do when this is approved