### PR TITLE
update pip mirror update policy, build deb package on each PR to verify policy is adhered to

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,35 @@ version: 2
 jobs:
   build:
     docker:
+      - image: circleci/python:3.5-stretch
+    steps:
+      - checkout
+
+      - run:
+          name: Install Debian packaging dependencies and download wheels
+          command: |
+            mkdir ~/packaging && cd ~/packaging
+            git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
+            cd securedrop-debian-packaging
+            make install-deps && make fetch-wheels
+
+      - run:
+          name: Tag and make source tarball
+          command: |
+            cd ~/project
+            ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
+            python3 setup.py sdist
+
+      - run:
+          name: Build debian package
+          command: |
+            cd ~/packaging/securedrop-debian-packaging
+            export PKG_VERSION=1000.0
+            export PKG_PATH=~/project/dist/securedrop-proxy-$PKG_VERSION.tar.gz
+            make securedrop-proxy
+
+  test:
+    docker:
       - image: circleci/python:3.5
     steps:
       - checkout
@@ -20,3 +49,10 @@ jobs:
             set -e
             source .venv/bin/activate
             make safety
+
+workflows:
+  version: 2
+  securedrop_proxy_ci:
+    jobs:
+      - test
+      - build

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ the updated dependency to our pip mirror (you can request this in the PR).
 
 3. Once the pip mirror is updated, you should checkout the [securedrop-debian-packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.
 
+## Making a Release
+
+**Note:** These are the release guidelines for pre-production alpha releases. Production release tags must be signed with the SecureDrop release key.
+
+ 1. Update versions: `./update_version.sh $new_version_number`.
+2. Commit the changes with commit message `securedrop-proxy $new_version_number` and make a PR.
+3. You should confirm via a manual debian package build and manual testing in Qubes that there are no regressions (this is limited pre-release QA).
+4. Once your PR is approved, you can add a tag and push: `git tag $new_version_number`.
+
 #### configuration
 
 The proxy script must be run with the path to its configuration file

--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ pip install --require-hashes -r dev-requirements.txt
 
 #### Update dependencies
 
-To add or update a dependency, modify either `dev-requirements.in` and `requirements.in` and then run `make update-pip-dependencies`. This will generate `dev-requirements.txt` and `requirements.txt`.
+If you're adding or updating a dependency, you need to:
 
-**IMPORTANT:** Do not modify `build-requirements.txt` during normal development. We use a pip mirror for our build process and the hashes in that file point to wheels on our mirror.
+1. Modify either `dev-requirements.in` and `requirements.in` (depending on whether it is prod or dev only) and then run `make update-pip-dependencies`. This will generate `dev-requirements.txt` and `requirements.txt`.
+
+2. For building a debian package from this project, we use the requirements in
+`build-requirements.txt` which uses our pip mirror, i.e. the hashes in that file point to
+wheels on our pip mirror. A maintainer will need to add
+the updated dependency to our pip mirror (you can request this in the PR).
+
+3. Once the pip mirror is updated, you should checkout the [securedrop-debian-packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.
 
 #### configuration
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+## Usage: ./update_version.sh <version>
+
+set -e
+
+readonly NEW_VERSION=$1
+
+if [ -z "$NEW_VERSION" ]; then
+  echo "You must specify the new version!"
+  exit 1
+fi
+
+# Get the old version from securedrop_proxy/VERSION
+OLD_VERSION=$(cat securedrop_proxy/VERSION)
+
+if [ -z "$OLD_VERSION" ]; then
+  echo "Couldn't find the old version: does this script need to be updated?"
+  exit 1
+fi
+
+# Update the version in securedrop_proxy/VERSION
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # The empty '' after sed -i is required on macOS to indicate no backup file should be saved.
+    sed -i '' "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" securedrop_proxy/VERSION
+else
+    sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" securedrop_proxy/VERSION
+fi


### PR DESCRIPTION
# Description

Changes in this repo for https://github.com/freedomofpress/securedrop-debian-packaging/issues/48

Closes #17

Closes #34 (discussion of versioning happening in https://github.com/freedomofpress/securedrop-client/issues/407 and the only proxy-specific changes are in this PR)

# Test Plan

CI/dev only so read the diff, make sure all makes sense, and make sure CI passes. You can also try `./update_version.sh <version>` locally.

Note that we'll need to modify the required checks for merge for the new job and renamed job, will do when this is approved