### PR TITLE
ci: fail build if build requirements need update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
             cd securedrop-debian-packaging
             make install-deps && make fetch-wheels
+            PKG_DIR=~/project make requirements
 
       - run:
           name: Tag and make source tarball


### PR DESCRIPTION
# Description

This is a followup from: #37

This is the same PR as in https://github.com/freedomofpress/securedrop-client/pull/436 just now for the proxy

`master` must _always_ produce a packaged proxy that is in a working state after build: in #37 we verified that the build succeeds on `master`. However: if `build-requirements.txt` is out of sync with `requirements.txt`, the proxy may not work as expected if it relies on functionality added in the new dependency added in `requirements.txt`. 

This PR runs `make requirements` prior to build such that the build will fail if `build-requirements.txt` is out of sync with `requirements.txt`