### PR TITLE
Edit qrexec policy instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ On `dom0`, create the file `/etc/qubes-rpc/policy/securedrop.Proxy`
 with the contents:
 
     securedrop-client securedrop-proxy allow
-    $anyvm $anyvm deny
+    @anyvm @anyvm deny
 
 (replacing the VM names with the correct source and destination names
 for your environment)

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ with the contents:
     securedrop-client securedrop-proxy allow
     @anyvm @anyvm deny
 
-(replacing the VM names with the correct source and destination names
-for your environment)
+Replace the VM names in the first line above with the correct source and
+destination names for your environment. The second line should appear as is.
 
 Also in `dom0`, edit `/etc/qubes-rpc/policy/qubes.Filecopy`, to add
 near the top:


### PR DESCRIPTION
Keywords in qrexec policy files should use the `@` character instead of `$`. (`$anyvm` should be `@anyvm`.)

See this security bulletin for context: https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-038-2018.txt