### PR TITLE
Add securedrop-proxy logging

### DIFF
--- a/securedrop_proxy/entrypoint.py
+++ b/securedrop_proxy/entrypoint.py
@@ -23,6 +23,7 @@ from securedrop_proxy.version import version
 
 
 DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".securedrop_proxy")
+LOGLEVEL = os.environ.get('LOGLEVEL', 'info').upper()
 
 
 def start():
@@ -98,7 +99,7 @@ def configure_logging() -> None:
 
     # set up primary log
     log = logging.getLogger()
-    log.setLevel(logging.DEBUG)
+    log.setLevel(LOGLEVEL)
     log.addHandler(handler)
 
     # override excepthook to capture a log of catastrophic failures.

--- a/securedrop_proxy/entrypoint.py
+++ b/securedrop_proxy/entrypoint.py
@@ -26,6 +26,16 @@ DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".securedrop_proxy")
 
 
 def start():
+    '''
+    Set up a new proxy object with an error handler, configuration that we read from  argv[1], and
+    the original user request from STDIN.
+    '''
+    try:
+        configure_logging()
+    except Exception as e:
+        print(e)
+        return
+
     logging.info('Starting SecureDrop Proxy {}'.format(version))
 
     # a fresh, new proxy object
@@ -67,7 +77,7 @@ def excepthook(*exc_args):
     sys.exit(1)
 
 
-def configure_logging(sdc_home: str) -> None:
+def configure_logging() -> None:
     '''
     All logging related settings are set up by this function.
     '''

--- a/securedrop_proxy/entrypoint.py
+++ b/securedrop_proxy/entrypoint.py
@@ -37,7 +37,7 @@ def start():
         print(e)
         return
 
-    logging.info('Starting SecureDrop Proxy {}'.format(version))
+    logging.debug('Starting SecureDrop Proxy {}'.format(version))
 
     # a fresh, new proxy object
     p = proxy.Proxy()

--- a/securedrop_proxy/main.py
+++ b/securedrop_proxy/main.py
@@ -1,24 +1,33 @@
 import json
+import logging
 
 from securedrop_proxy import callbacks
 from securedrop_proxy import proxy
 
 
+logger = logging.getLogger(__name__)
+
+
 def __main__(incoming, p):
-    # deserialize incoming request
+    '''
+    Deserialize incoming request in order to build and send a proxy request.
+    '''
+    logging.debug('Creating request to be sent by proxy')
+
     client_req = None
     try:
         client_req = json.loads(incoming)
-    except json.decoder.JSONDecodeError:
+    except json.decoder.JSONDecodeError as e:
+        logging.error(e)
         p.simple_error(400, 'Invalid JSON in request')
         p.on_done(p.res)
 
-    # build request oject
     req = proxy.Req()
     try:
         req.method = client_req['method']
         req.path_query = client_req['path_query']
-    except KeyError:
+    except KeyError as e:
+        logging.error(e)
         p.simple_error(400, 'Missing keys in request')
         p.on_done(p.res)
 
@@ -28,7 +37,6 @@ def __main__(incoming, p):
     if "body" in client_req:
         req.body = client_req['body']
 
-    # complete proxy object
     p.req = req
     p.on_save = callbacks.on_save
     p.on_done = callbacks.on_done

--- a/securedrop_proxy/proxy.py
+++ b/securedrop_proxy/proxy.py
@@ -103,7 +103,7 @@ class Proxy:
         res = Response(self._presp.status_code)
 
         # Create a NamedTemporaryFile, we don't want
-        # to delete it after closign.
+        # to delete it after closing.
         fh = tempfile.NamedTemporaryFile(delete=False)
 
         for c in self._presp.iter_content(10):


### PR DESCRIPTION
Resolves #44 

## Test

1. Make a `securedrop-proxy` debian package from this branch
2. Copy it to `sd-proxy` VM (you might need to add a FileCopy policy to allow this
3. `dpkg` install it
4. Run the client
5. Tail `~/.securedrop-proxy/logs/proxy.log` in `sd-proxy` and see your requests going through

I was able to cause a `BrokenPipeError` and see the traceback in the logs. The proxy was able to gracefully recover on the next request, but we now have record of things like that happening.