### PR TITLE
ci: ensure that requirements files are in sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,14 @@ jobs:
             PKG_DIR=~/project make requirements
 
       - run:
+          name: Ensure that build-requirements.txt and requirements.txt are in sync.
+          command: |
+            cd ~/project
+            # Return 1 if unstaged changes exist (after `make requirements` in the 
+            # previous run step), else return 0.
+            git diff --quiet
+
+      - run:
           name: Tag and make source tarball
           command: |
             cd ~/project


### PR DESCRIPTION
This PR guards against a scenario discovered [here](https://github.com/freedomofpress/securedrop-proxy/pull/46#issuecomment-545589326) wherein a contributor would update `build-requirements.txt` but not `requirements.txt` and our build would pass in CI. We want to ensure that these requirements files are kept in sync and prevent merge of diffs that update one but not the other. 

To confirm this change works as expected, you can inspect:
* the previous build job based on this scenario (passing): https://circleci.com/gh/freedomofpress/securedrop-proxy/101
* the build job with this change (failing as expected, based on branch [demonstrate-failing-build](https://github.com/freedomofpress/securedrop-proxy/tree/demonstrate-failing-build)): https://circleci.com/gh/freedomofpress/securedrop-proxy/113
