### PR TITLE
Improve error handling, tests

### DIFF
--- a/fixtures/main_error_response.yaml
+++ b/fixtures/main_error_response.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+    method: ''
+    uri: https://jsonplaceholder.typicode.com/
+  response:
+    body:
+      string: "<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n\
+        <center><h1>400 Bad Request</h1></center>\r\n<hr><center>cloudflare</center>\r\
+        \n</body>\r\n</html>\r\n"
+    headers:
+      CF-RAY:
+      - '-'
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 16 Dec 2019 22:11:39 GMT
+      Server:
+      - cloudflare
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/fixtures/main_input_body.yaml
+++ b/fixtures/main_input_body.yaml
@@ -1,0 +1,59 @@
+interactions:
+- request:
+    body: id=42&title=test
+    headers:
+      Content-Length:
+      - '16'
+      Content-Type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://jsonplaceholder.typicode.com/posts
+  response:
+    body:
+      string: "{\n  \"id\": 101,\n  \"title\": \"test\"\n}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - Location
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 546ab6213f81f11a-IAD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Dec 2019 17:45:33 GMT
+      Etag:
+      - W/"22-i04alCk7PdGrJ2UKCUwBOO0LB3w"
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - '-1'
+      Location:
+      - http://jsonplaceholder.typicode.com/posts/101
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cfduid=d1fa880178dc2db917f26b8ce4e0d56e41576604733; expires=Thu, 16-Jan-20
+        17:45:33 GMT; path=/; domain=.typicode.com; HttpOnly; SameSite=Lax
+      Vary:
+      - Origin, X-HTTP-Method-Override, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/fixtures/main_input_headers.yaml
+++ b/fixtures/main_input_headers.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: null
+    headers:
+      X-Test-Header:
+      - th
+    method: GET
+    uri: https://jsonplaceholder.typicode.com/posts?userId=1
+  response:
+    body:
+      string: "[\n  {\n    \"userId\": 1,\n    \"id\": 1,\n    \"title\": \"sunt aut\
+        \ facere repellat provident occaecati excepturi optio reprehenderit\",\n \
+        \   \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita\
+        \ et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem\
+        \ sunt rem eveniet architecto\"\n  },\n  {\n    \"userId\": 1,\n    \"id\"\
+        : 2,\n    \"title\": \"qui est esse\",\n    \"body\": \"est rerum tempore\
+        \ vitae\\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\\nfugiat\
+        \ blanditiis voluptate porro vel nihil molestiae ut reiciendis\\nqui aperiam\
+        \ non debitis possimus qui neque nisi nulla\"\n  },\n  {\n    \"userId\":\
+        \ 1,\n    \"id\": 3,\n    \"title\": \"ea molestias quasi exercitationem repellat\
+        \ qui ipsa sit aut\",\n    \"body\": \"et iusto sed quo iure\\nvoluptatem\
+        \ occaecati omnis eligendi aut ad\\nvoluptatem doloribus vel accusantium quis\
+        \ pariatur\\nmolestiae porro eius odio et labore et velit aut\"\n  },\n  {\n\
+        \    \"userId\": 1,\n    \"id\": 4,\n    \"title\": \"eum et est occaecati\"\
+        ,\n    \"body\": \"ullam et saepe reiciendis voluptatem adipisci\\nsit amet\
+        \ autem assumenda provident rerum culpa\\nquis hic commodi nesciunt rem tenetur\
+        \ doloremque ipsam iure\\nquis sunt voluptatem rerum illo velit\"\n  },\n\
+        \  {\n    \"userId\": 1,\n    \"id\": 5,\n    \"title\": \"nesciunt quas odio\"\
+        ,\n    \"body\": \"repudiandae veniam quaerat sunt sed\\nalias aut fugiat\
+        \ sit autem sed est\\nvoluptatem omnis possimus esse voluptatibus quis\\nest\
+        \ aut tenetur dolor neque\"\n  },\n  {\n    \"userId\": 1,\n    \"id\": 6,\n\
+        \    \"title\": \"dolorem eum magni eos aperiam quia\",\n    \"body\": \"\
+        ut aspernatur corporis harum nihil quis provident sequi\\nmollitia nobis aliquid\
+        \ molestiae\\nperspiciatis et ea nemo ab reprehenderit accusantium quas\\\
+        nvoluptate dolores velit et doloremque molestiae\"\n  },\n  {\n    \"userId\"\
+        : 1,\n    \"id\": 7,\n    \"title\": \"magnam facilis autem\",\n    \"body\"\
+        : \"dolore placeat quibusdam ea quo vitae\\nmagni quis enim qui quis quo nemo\
+        \ aut saepe\\nquidem repellat excepturi ut quia\\nsunt ut sequi eos ea sed\
+        \ quas\"\n  },\n  {\n    \"userId\": 1,\n    \"id\": 8,\n    \"title\": \"\
+        dolorem dolore est ipsam\",\n    \"body\": \"dignissimos aperiam dolorem qui\
+        \ eum\\nfacilis quibusdam animi sint suscipit qui sint possimus cum\\nquaerat\
+        \ magni maiores excepturi\\nipsam ut commodi dolor voluptatum modi aut vitae\"\
+        \n  },\n  {\n    \"userId\": 1,\n    \"id\": 9,\n    \"title\": \"nesciunt\
+        \ iure omnis dolorem tempora et accusantium\",\n    \"body\": \"consectetur\
+        \ animi nesciunt iure dolore\\nenim quia ad\\nveniam autem ut quam aut nobis\\\
+        net est aut quod aut provident voluptas autem voluptas\"\n  },\n  {\n    \"\
+        userId\": 1,\n    \"id\": 10,\n    \"title\": \"optio molestias id quia eum\"\
+        ,\n    \"body\": \"quo et expedita modi cum officia vel magni\\ndoloribus\
+        \ qui repudiandae\\nvero nisi sit\\nquos veniam quod sed accusamus veritatis\
+        \ error\"\n  }\n]"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Age:
+      - '1789'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 54722d954de5e0ea-IAD
+      Cache-Control:
+      - max-age=14400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Dec 2019 15:30:26 GMT
+      Etag:
+      - W/"aa6-j2NSH739l9uq40OywFMn7Y0C/iY"
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cfduid=d21e159ad4987bc5ba9d781aed2f9db5c1576683026; expires=Fri, 17-Jan-20
+        15:30:26 GMT; path=/; domain=.typicode.com; HttpOnly; SameSite=Lax
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/main_json_response.yaml
+++ b/fixtures/main_json_response.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://jsonplaceholder.typicode.com/posts?userId=1
+  response:
+    body:
+      string: "[\n  {\n    \"userId\": 1,\n    \"id\": 1,\n    \"title\": \"sunt aut\
+        \ facere repellat provident occaecati excepturi optio reprehenderit\",\n \
+        \   \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita\
+        \ et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem\
+        \ sunt rem eveniet architecto\"\n  },\n  {\n    \"userId\": 1,\n    \"id\"\
+        : 2,\n    \"title\": \"qui est esse\",\n    \"body\": \"est rerum tempore\
+        \ vitae\\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\\nfugiat\
+        \ blanditiis voluptate porro vel nihil molestiae ut reiciendis\\nqui aperiam\
+        \ non debitis possimus qui neque nisi nulla\"\n  },\n  {\n    \"userId\":\
+        \ 1,\n    \"id\": 3,\n    \"title\": \"ea molestias quasi exercitationem repellat\
+        \ qui ipsa sit aut\",\n    \"body\": \"et iusto sed quo iure\\nvoluptatem\
+        \ occaecati omnis eligendi aut ad\\nvoluptatem doloribus vel accusantium quis\
+        \ pariatur\\nmolestiae porro eius odio et labore et velit aut\"\n  },\n  {\n\
+        \    \"userId\": 1,\n    \"id\": 4,\n    \"title\": \"eum et est occaecati\"\
+        ,\n    \"body\": \"ullam et saepe reiciendis voluptatem adipisci\\nsit amet\
+        \ autem assumenda provident rerum culpa\\nquis hic commodi nesciunt rem tenetur\
+        \ doloremque ipsam iure\\nquis sunt voluptatem rerum illo velit\"\n  },\n\
+        \  {\n    \"userId\": 1,\n    \"id\": 5,\n    \"title\": \"nesciunt quas odio\"\
+        ,\n    \"body\": \"repudiandae veniam quaerat sunt sed\\nalias aut fugiat\
+        \ sit autem sed est\\nvoluptatem omnis possimus esse voluptatibus quis\\nest\
+        \ aut tenetur dolor neque\"\n  },\n  {\n    \"userId\": 1,\n    \"id\": 6,\n\
+        \    \"title\": \"dolorem eum magni eos aperiam quia\",\n    \"body\": \"\
+        ut aspernatur corporis harum nihil quis provident sequi\\nmollitia nobis aliquid\
+        \ molestiae\\nperspiciatis et ea nemo ab reprehenderit accusantium quas\\\
+        nvoluptate dolores velit et doloremque molestiae\"\n  },\n  {\n    \"userId\"\
+        : 1,\n    \"id\": 7,\n    \"title\": \"magnam facilis autem\",\n    \"body\"\
+        : \"dolore placeat quibusdam ea quo vitae\\nmagni quis enim qui quis quo nemo\
+        \ aut saepe\\nquidem repellat excepturi ut quia\\nsunt ut sequi eos ea sed\
+        \ quas\"\n  },\n  {\n    \"userId\": 1,\n    \"id\": 8,\n    \"title\": \"\
+        dolorem dolore est ipsam\",\n    \"body\": \"dignissimos aperiam dolorem qui\
+        \ eum\\nfacilis quibusdam animi sint suscipit qui sint possimus cum\\nquaerat\
+        \ magni maiores excepturi\\nipsam ut commodi dolor voluptatum modi aut vitae\"\
+        \n  },\n  {\n    \"userId\": 1,\n    \"id\": 9,\n    \"title\": \"nesciunt\
+        \ iure omnis dolorem tempora et accusantium\",\n    \"body\": \"consectetur\
+        \ animi nesciunt iure dolore\\nenim quia ad\\nveniam autem ut quam aut nobis\\\
+        net est aut quod aut provident voluptas autem voluptas\"\n  },\n  {\n    \"\
+        userId\": 1,\n    \"id\": 10,\n    \"title\": \"optio molestias id quia eum\"\
+        ,\n    \"body\": \"quo et expedita modi cum officia vel magni\\ndoloribus\
+        \ qui repudiandae\\nvero nisi sit\\nquos veniam quod sed accusamus veritatis\
+        \ error\"\n  }\n]"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Age:
+      - '4646'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 54640259fa6fe0d2-IAD
+      Cache-Control:
+      - max-age=14400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 16 Dec 2019 22:14:15 GMT
+      Etag:
+      - W/"aa6-j2NSH739l9uq40OywFMn7Y0C/iY"
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cfduid=d8ac1a396d31b9e9c1f816924e5bf186d1576534455; expires=Wed, 15-Jan-20
+        22:14:15 GMT; path=/; domain=.typicode.com; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/main_non_json_response.yaml
+++ b/fixtures/main_non_json_response.yaml
@@ -1,0 +1,145 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://jsonplaceholder.typicode.com/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\"\
+        \ />\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1,\
+        \ shrink-to-fit=no\" />\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/0.5.0/modern-normalize.min.css\"\
+        \ />\n<link rel=\"stylesheet\" href=\"./style.css\" />\n<link rel=\"stylesheet\"\
+        \ href=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css\"\
+        \ />\n<script src=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js\"\
+        ></script>\n<link rel=\"stylesheet\" href=\"https://use.fontawesome.com/releases/v5.5.0/css/all.css\"\
+        \ integrity=\"sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU\"\
+        \ crossorigin=\"anonymous\" />\n<script>\n      hljs.initHighlightingOnLoad();\n\
+        \    </script>\n<title>JSONPlaceholder - Fake online REST API for developers</title>\n\
+        </head>\n<body>\n<header>\n<nav class=\"container\">\n<ul>\n<li><a href=\"\
+        /\">JSONPlaceholder</a></li>\n<li><a href=\"/guide.html\">Guide</a></li>\n\
+        <li><a href=\"https://github.com/typicode\">GitHub</a></li>\n<li>\n<a href=\"\
+        https://my-json-server.typicode.com\">My JSON Server</a>\n</li>\n</ul>\n</nav>\n\
+        <a href=\"https://github.com/users/typicode/sponsorship\" class=\"announcement\"\
+        >\n<i class=\"fab fa-github-alt\"></i> Announcement: You can now support\n\
+        JSONPlaceholder on GitHub Sponsors!\n</a>\n</header>\n<div class=\"container\"\
+        >\n\n<div class=\"hero\">\n<div class=\"container\">\n<h1>\nJSONPlaceholder\n\
+        </h1>\n<p class=\"subtitle\">\nFake Online REST API for Testing and Prototyping\n\
+        <br> <b>Serving ~350M requests per month</b>\n<br> Powered by\n<a href=\"\
+        https://github.com/typicode/json-server\">JSON Server</a>\n+\n<a href=\"https://github.com/typicode/lowdb\"\
+        >LowDB</a>\n</p>\n\n\n\n\n\n</div>\n</div>\n\n<div class=\"sponsors\">\n<h3>Gold\
+        \ Sponsors</h3>\n<p>\n<a href=\"https://tryretool.com/?utm_source=sponsor&utm_campaign=typicode\"\
+        \ target=\"_blank\">\n<img src=\"https://i.imgur.com/IBItATn.png\" height=\"\
+        70px\">\n</a>\n</p>\n<p>\n<a href=\"https://www.patreon.com/bePatron?c=784328\"\
+        >Your Company Logo Here</a>\n</p>\n</div>\n\n<div class=\"container\">\n<main>\n\
+        \n<h2>Intro</h2>\n<p>\nJSONPlaceholder is a free online REST API that you\
+        \ can use whenever you need some fake data.\n<br>It's great for tutorials,\
+        \ testing new libraries, sharing code examples, ...\n</p>\n\n<h2>Example</h2>\n\
+        <p>\nRun this code in a console or from any site:\n</p>\n<pre><code id=\"\
+        example\" class=\"javascript\">fetch('https://jsonplaceholder.typicode.com/todos/1')\n\
+        \  .then(response => response.json())\n  .then(json => console.log(json))\n\
+        </code></pre>\n<p>\n<button id=\"run-button\">Try it</button>\n</p>\n<pre><code\
+        \ id=\"result\" class=\"json\"></code></pre>\n<span id=\"run-message\">Congrats\
+        \ you've made your first call to JSONPlaceholder! \U0001F603 \U0001F389</span>\n\
+        <p>\n<strong>Tip</strong>: you can use\n<b>\nhttp://\n</b> or\n<b>\nhttps://\n\
+        </b> when making requests to JSONPlaceholder.\n</p>\n<div id=\"codefund\"\
+        ></div>\n<script src=\"https://codefund.io/properties/338/funder.js\" async=\"\
+        async\"></script>\n\n<h2>Resources</h2>\n<p>\nJSONPlaceholder comes with a\
+        \ set of 6 common resources:\n</p>\n<table class=\"resources\">\n<tr>\n<td>\n\
+        \ <a href=\"/posts\">/posts</a>\n</td>\n<td>100 posts</td>\n</tr>\n<tr>\n\
+        <td>\n<a href=\"/comments\">/comments</a>\n</td>\n<td>500 comments</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/albums\">/albums</a>\n</td>\n<td>100 albums</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/photos\">/photos</a>\n</td>\n<td>5000 photos</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/todos\">/todos</a>\n</td>\n<td>200 todos</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/users\">/users</a>\n</td>\n<td>10 users</td>\n\
+        </tr>\n</table>\n<p>\n<strong>Note</strong>: resources have relations. For\
+        \ example:\n<b>posts</b> have many\n<b>comments</b>,\n<b>albums</b> have many\n\
+        <b>photos</b>, ... see below for routes examples.\n</p>\n\n<h2>Routes</h2>\n\
+        <p>\nAll HTTP methods are supported.\n</p>\n<table>\n<tr>\n<td>GET</td>\n\
+        <td>\n<a href=\"/posts\">/posts</a>\n</td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n\
+        <a href=\"/posts/1\">/posts/1</a>\n</td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n\
+        <a href=\"/posts/1/comments\">/posts/1/comments</a>\n</td>\n</tr>\n<tr>\n\
+        <td>GET</td>\n<td>\n<a href=\"/comments?postId=1\">/comments?postId=1</a>\n\
+        </td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n<a href=\"/posts?userId=1\">/posts?userId=1</a>\n\
+        </td>\n</tr>\n<tr>\n<td>POST</td>\n<td>/posts</td>\n</tr>\n<tr>\n<td>PUT</td>\n\
+        <td>/posts/1</td>\n</tr>\n<tr>\n<td>PATCH</td>\n<td>/posts/1</td>\n</tr>\n\
+        <tr>\n<td>DELETE</td>\n<td>/posts/1</td>\n</tr>\n</tr>\n</table>\n<p>\n<strong>Note</strong>:\
+        \ you can view detailed examples\n<a href=\"guide.html\">here</a>.\n</p>\n\
+        \n<h2>Use your own data</h2>\n\n<p>\nWith <a href=\"https://my-json-server.typicode.com\"\
+        >My JSON Server</a> online service and a simple GitHub repo, you can have\
+        \ your own online fake REST server in seconds.\n</p>\n</main>\n</div>\n</div>\n\
+        \n<footer>\n<div class=\"container\">\n<div style=\"margin-bottom: 2rem\"\
+        >\n\n\n\n\n\n\n<a href=\"https://github.com/users/typicode/sponsorship\">\n\
+        <i class=\"fab fa-github-alt\"></i> Sponsor this project on GitHub\n</a>\n\
+        </div>\n<div>\nCoded and built with \u2764\uFE0F by\n<a href=\"https://github.com/typicode\"\
+        >typicode</a>\n<br />Source code and CHANGELOG available on\n<a href=\"https://github.com/typicode/jsonplaceholder\"\
+        >GitHub</a>\n</div>\n</div>\n</footer>\n\n<script>\n      (function(i, s,\
+        \ o, g, r, a, m) {\n        i[\"GoogleAnalyticsObject\"] = r;\n        (i[r]\
+        \ =\n          i[r] ||\n          function() {\n            (i[r].q = i[r].q\
+        \ || []).push(arguments);\n          }),\n          (i[r].l = 1 * new Date());\n\
+        \        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);\n \
+        \       a.async = 1;\n        a.src = g;\n        m.parentNode.insertBefore(a,\
+        \ m);\n      })(\n        window,\n        document,\n        \"script\",\n\
+        \        \"//www.google-analytics.com/analytics.js\",\n        \"ga\"\n  \
+        \    );\n      ga(\"create\", \"UA-44497010-1\", \"typicode.com\");\n    \
+        \  ga(\"send\", \"pageview\");\n      var trackOutboundLink = function(url)\
+        \ {\n        ga(\"send\", \"event\", \"outbound\", \"click\", url, {\n   \
+        \       transport: \"beacon\"\n        });\n      };\n    </script>\n<script\
+        \ src=\"//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js\"></script>\n\
+        <script>\n      // Use http or https based on location.protocol\n      var\
+        \ example = document.getElementById(\"example\");\n      example.textContent\
+        \ = example.textContent.replace(\n        \"http:\",\n        location.protocol\n\
+        \      );\n\n      // Highlight result element\n      var result = document.getElementById(\"\
+        result\");\n      hljs.highlightBlock(result);\n\n      // Run example\n \
+        \     var runButton = document.getElementById(\"run-button\");\n      runButton.onclick\
+        \ = function() {\n        var root = location.protocol + \"//jsonplaceholder.typicode.com\"\
+        ;\n        var runMessage = document.getElementById(\"run-message\");\n\n\
+        \        // Hide or disable things during API call\n        runButton.disabled\
+        \ = true;\n        runMessage.style.opacity = 0;\n        result.style.opacity\
+        \ = 0;\n\n        fetch(\"https://jsonplaceholder.typicode.com/todos/1\")\n\
+        \          .then(response => response.json())\n          .then(json => {\n\
+        \            var str = JSON.stringify(json, null, \"\\t\");\n\n          \
+        \  // Format result\n            result.innerHTML = str\n              .replace(/\\\
+        n/g, \"<br/>\")\n              .replace(/\\\\n/g, \" \")\n              .replace(/\\\
+        t/g, \"&nbsp;&nbsp;\");\n\n            hljs.highlightBlock(result);\n\n  \
+        \          // Show and enable things after API call\n            runButton.disabled\
+        \ = false;\n            runMessage.style.opacity = 1;\n            result.style.opacity\
+        \ = 1;\n          });\n      };\n    </script>\n</body>\n</html>\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Age:
+      - '5668'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 5463fe6ccb0ecf04-IAD
+      Cache-Control:
+      - public, max-age=14400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 16 Dec 2019 22:11:34 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Last-Modified:
+      - Mon, 05 Aug 2019 03:07:14 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cfduid=d13b55a7f6e786f74d5f9f1f084a183a31576534294; expires=Wed, 15-Jan-20
+        22:11:34 GMT; path=/; domain=.typicode.com; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/proxy_bad_request.yaml
+++ b/fixtures/proxy_bad_request.yaml
@@ -1,0 +1,20 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/bad
+  response:
+    body:
+      string: ''
+    headers:
+      Date:
+      - Mon, 16 Dec 2019 23:44:53 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.7.3
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/fixtures/proxy_callbacks.yaml
+++ b/fixtures/proxy_callbacks.yaml
@@ -1,0 +1,145 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://jsonplaceholder.typicode.com/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\"\
+        \ />\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1,\
+        \ shrink-to-fit=no\" />\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/0.5.0/modern-normalize.min.css\"\
+        \ />\n<link rel=\"stylesheet\" href=\"./style.css\" />\n<link rel=\"stylesheet\"\
+        \ href=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css\"\
+        \ />\n<script src=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js\"\
+        ></script>\n<link rel=\"stylesheet\" href=\"https://use.fontawesome.com/releases/v5.5.0/css/all.css\"\
+        \ integrity=\"sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU\"\
+        \ crossorigin=\"anonymous\" />\n<script>\n      hljs.initHighlightingOnLoad();\n\
+        \    </script>\n<title>JSONPlaceholder - Fake online REST API for developers</title>\n\
+        </head>\n<body>\n<header>\n<nav class=\"container\">\n<ul>\n<li><a href=\"\
+        /\">JSONPlaceholder</a></li>\n<li><a href=\"/guide.html\">Guide</a></li>\n\
+        <li><a href=\"https://github.com/typicode\">GitHub</a></li>\n<li>\n<a href=\"\
+        https://my-json-server.typicode.com\">My JSON Server</a>\n</li>\n</ul>\n</nav>\n\
+        <a href=\"https://github.com/users/typicode/sponsorship\" class=\"announcement\"\
+        >\n<i class=\"fab fa-github-alt\"></i> Announcement: You can now support\n\
+        JSONPlaceholder on GitHub Sponsors!\n</a>\n</header>\n<div class=\"container\"\
+        >\n\n<div class=\"hero\">\n<div class=\"container\">\n<h1>\nJSONPlaceholder\n\
+        </h1>\n<p class=\"subtitle\">\nFake Online REST API for Testing and Prototyping\n\
+        <br> <b>Serving ~350M requests per month</b>\n<br> Powered by\n<a href=\"\
+        https://github.com/typicode/json-server\">JSON Server</a>\n+\n<a href=\"https://github.com/typicode/lowdb\"\
+        >LowDB</a>\n</p>\n\n\n\n\n\n</div>\n</div>\n\n<div class=\"sponsors\">\n<h3>Gold\
+        \ Sponsors</h3>\n<p>\n<a href=\"https://tryretool.com/?utm_source=sponsor&utm_campaign=typicode\"\
+        \ target=\"_blank\">\n<img src=\"https://i.imgur.com/IBItATn.png\" height=\"\
+        70px\">\n</a>\n</p>\n<p>\n<a href=\"https://www.patreon.com/bePatron?c=784328\"\
+        >Your Company Logo Here</a>\n</p>\n</div>\n\n<div class=\"container\">\n<main>\n\
+        \n<h2>Intro</h2>\n<p>\nJSONPlaceholder is a free online REST API that you\
+        \ can use whenever you need some fake data.\n<br>It's great for tutorials,\
+        \ testing new libraries, sharing code examples, ...\n</p>\n\n<h2>Example</h2>\n\
+        <p>\nRun this code in a console or from any site:\n</p>\n<pre><code id=\"\
+        example\" class=\"javascript\">fetch('https://jsonplaceholder.typicode.com/todos/1')\n\
+        \  .then(response => response.json())\n  .then(json => console.log(json))\n\
+        </code></pre>\n<p>\n<button id=\"run-button\">Try it</button>\n</p>\n<pre><code\
+        \ id=\"result\" class=\"json\"></code></pre>\n<span id=\"run-message\">Congrats\
+        \ you've made your first call to JSONPlaceholder! \U0001F603 \U0001F389</span>\n\
+        <p>\n<strong>Tip</strong>: you can use\n<b>\nhttp://\n</b> or\n<b>\nhttps://\n\
+        </b> when making requests to JSONPlaceholder.\n</p>\n<div id=\"codefund\"\
+        ></div>\n<script src=\"https://codefund.io/properties/338/funder.js\" async=\"\
+        async\"></script>\n\n<h2>Resources</h2>\n<p>\nJSONPlaceholder comes with a\
+        \ set of 6 common resources:\n</p>\n<table class=\"resources\">\n<tr>\n<td>\n\
+        \ <a href=\"/posts\">/posts</a>\n</td>\n<td>100 posts</td>\n</tr>\n<tr>\n\
+        <td>\n<a href=\"/comments\">/comments</a>\n</td>\n<td>500 comments</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/albums\">/albums</a>\n</td>\n<td>100 albums</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/photos\">/photos</a>\n</td>\n<td>5000 photos</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/todos\">/todos</a>\n</td>\n<td>200 todos</td>\n\
+        </tr>\n<tr>\n<td>\n<a href=\"/users\">/users</a>\n</td>\n<td>10 users</td>\n\
+        </tr>\n</table>\n<p>\n<strong>Note</strong>: resources have relations. For\
+        \ example:\n<b>posts</b> have many\n<b>comments</b>,\n<b>albums</b> have many\n\
+        <b>photos</b>, ... see below for routes examples.\n</p>\n\n<h2>Routes</h2>\n\
+        <p>\nAll HTTP methods are supported.\n</p>\n<table>\n<tr>\n<td>GET</td>\n\
+        <td>\n<a href=\"/posts\">/posts</a>\n</td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n\
+        <a href=\"/posts/1\">/posts/1</a>\n</td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n\
+        <a href=\"/posts/1/comments\">/posts/1/comments</a>\n</td>\n</tr>\n<tr>\n\
+        <td>GET</td>\n<td>\n<a href=\"/comments?postId=1\">/comments?postId=1</a>\n\
+        </td>\n</tr>\n<tr>\n<td>GET</td>\n<td>\n<a href=\"/posts?userId=1\">/posts?userId=1</a>\n\
+        </td>\n</tr>\n<tr>\n<td>POST</td>\n<td>/posts</td>\n</tr>\n<tr>\n<td>PUT</td>\n\
+        <td>/posts/1</td>\n</tr>\n<tr>\n<td>PATCH</td>\n<td>/posts/1</td>\n</tr>\n\
+        <tr>\n<td>DELETE</td>\n<td>/posts/1</td>\n</tr>\n</tr>\n</table>\n<p>\n<strong>Note</strong>:\
+        \ you can view detailed examples\n<a href=\"guide.html\">here</a>.\n</p>\n\
+        \n<h2>Use your own data</h2>\n\n<p>\nWith <a href=\"https://my-json-server.typicode.com\"\
+        >My JSON Server</a> online service and a simple GitHub repo, you can have\
+        \ your own online fake REST server in seconds.\n</p>\n</main>\n</div>\n</div>\n\
+        \n<footer>\n<div class=\"container\">\n<div style=\"margin-bottom: 2rem\"\
+        >\n\n\n\n\n\n\n<a href=\"https://github.com/users/typicode/sponsorship\">\n\
+        <i class=\"fab fa-github-alt\"></i> Sponsor this project on GitHub\n</a>\n\
+        </div>\n<div>\nCoded and built with \u2764\uFE0F by\n<a href=\"https://github.com/typicode\"\
+        >typicode</a>\n<br />Source code and CHANGELOG available on\n<a href=\"https://github.com/typicode/jsonplaceholder\"\
+        >GitHub</a>\n</div>\n</div>\n</footer>\n\n<script>\n      (function(i, s,\
+        \ o, g, r, a, m) {\n        i[\"GoogleAnalyticsObject\"] = r;\n        (i[r]\
+        \ =\n          i[r] ||\n          function() {\n            (i[r].q = i[r].q\
+        \ || []).push(arguments);\n          }),\n          (i[r].l = 1 * new Date());\n\
+        \        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);\n \
+        \       a.async = 1;\n        a.src = g;\n        m.parentNode.insertBefore(a,\
+        \ m);\n      })(\n        window,\n        document,\n        \"script\",\n\
+        \        \"//www.google-analytics.com/analytics.js\",\n        \"ga\"\n  \
+        \    );\n      ga(\"create\", \"UA-44497010-1\", \"typicode.com\");\n    \
+        \  ga(\"send\", \"pageview\");\n      var trackOutboundLink = function(url)\
+        \ {\n        ga(\"send\", \"event\", \"outbound\", \"click\", url, {\n   \
+        \       transport: \"beacon\"\n        });\n      };\n    </script>\n<script\
+        \ src=\"//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js\"></script>\n\
+        <script>\n      // Use http or https based on location.protocol\n      var\
+        \ example = document.getElementById(\"example\");\n      example.textContent\
+        \ = example.textContent.replace(\n        \"http:\",\n        location.protocol\n\
+        \      );\n\n      // Highlight result element\n      var result = document.getElementById(\"\
+        result\");\n      hljs.highlightBlock(result);\n\n      // Run example\n \
+        \     var runButton = document.getElementById(\"run-button\");\n      runButton.onclick\
+        \ = function() {\n        var root = location.protocol + \"//jsonplaceholder.typicode.com\"\
+        ;\n        var runMessage = document.getElementById(\"run-message\");\n\n\
+        \        // Hide or disable things during API call\n        runButton.disabled\
+        \ = true;\n        runMessage.style.opacity = 0;\n        result.style.opacity\
+        \ = 0;\n\n        fetch(\"https://jsonplaceholder.typicode.com/todos/1\")\n\
+        \          .then(response => response.json())\n          .then(json => {\n\
+        \            var str = JSON.stringify(json, null, \"\\t\");\n\n          \
+        \  // Format result\n            result.innerHTML = str\n              .replace(/\\\
+        n/g, \"<br/>\")\n              .replace(/\\\\n/g, \" \")\n              .replace(/\\\
+        t/g, \"&nbsp;&nbsp;\");\n\n            hljs.highlightBlock(result);\n\n  \
+        \          // Show and enable things after API call\n            runButton.disabled\
+        \ = false;\n            runMessage.style.opacity = 1;\n            result.style.opacity\
+        \ = 1;\n          });\n      };\n    </script>\n</body>\n</html>\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Age:
+      - '4432'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 5469de47682ecf00-IAD
+      Cache-Control:
+      - public, max-age=14400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Tue, 17 Dec 2019 15:18:12 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Last-Modified:
+      - Mon, 05 Aug 2019 03:07:14 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cfduid=dc33ebab29f22c648b958d03fed5596b51576595892; expires=Thu, 16-Jan-20
+        15:18:12 GMT; path=/; domain=.typicode.com; HttpOnly; SameSite=Lax
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 vegur
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/proxy_cannot_connect.yaml
+++ b/fixtures/proxy_cannot_connect.yaml
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/
+  response:
+    body:
+      string: 'hello
+
+        '
+    headers:
+      Date:
+      - Tue, 17 Dec 2019 00:06:22 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.7.3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/proxy_internal_error.yaml
+++ b/fixtures/proxy_internal_error.yaml
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/
+  response:
+    body:
+      string: 'hello
+
+        '
+    headers:
+      Date:
+      - Tue, 17 Dec 2019 00:00:13 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.7.3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/fixtures/proxy_internal_server_error.yaml
+++ b/fixtures/proxy_internal_server_error.yaml
@@ -1,0 +1,20 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/crash
+  response:
+    body:
+      string: ''
+    headers:
+      Date:
+      - Mon, 16 Dec 2019 23:58:10 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.7.3
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/fixtures/proxy_unofficial_status.yaml
+++ b/fixtures/proxy_unofficial_status.yaml
@@ -1,0 +1,20 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/teapot
+  response:
+    body:
+      string: ''
+    headers:
+      Date:
+      - Mon, 16 Dec 2019 23:59:52 GMT
+      Server:
+      - BaseHTTP/0.6 Python/3.7.3
+    status:
+      code: 418
+      message: ''
+version: 1

--- a/securedrop_proxy/main.py
+++ b/securedrop_proxy/main.py
@@ -39,6 +39,6 @@ def __main__(incoming, p):
         req.body = client_req['body']
 
     p.req = req
-    if p.on_save is None:
+    if not p.on_save:
         p.on_save = callbacks.on_save
     p.proxy()

--- a/securedrop_proxy/main.py
+++ b/securedrop_proxy/main.py
@@ -21,6 +21,7 @@ def __main__(incoming, p):
         logging.error(e)
         p.simple_error(400, 'Invalid JSON in request')
         p.on_done(p.res)
+        return
 
     req = proxy.Req()
     try:
@@ -38,6 +39,6 @@ def __main__(incoming, p):
         req.body = client_req['body']
 
     p.req = req
-    p.on_save = callbacks.on_save
-    p.on_done = callbacks.on_done
+    if p.on_save is None:
+        p.on_save = callbacks.on_save
     p.proxy()

--- a/securedrop_proxy/proxy.py
+++ b/securedrop_proxy/proxy.py
@@ -35,14 +35,14 @@ class Proxy:
         self.req = req
         self.res = None
         self.on_save = on_save
-        if on_done is not None:
+        if on_done:
             self.on_done = on_done
 
         self.timeout = float(timeout) if timeout else 10
 
         self._prepared_request = None
 
-    def on_done(self, res):
+    def on_done(self, res):  # type: ignore
         callbacks.on_done(res)
 
     @staticmethod

--- a/securedrop_proxy/proxy.py
+++ b/securedrop_proxy/proxy.py
@@ -135,7 +135,7 @@ class Proxy:
     def proxy(self):
 
         try:
-            if self.on_save is None:
+            if not self.on_save:
                 self.simple_error(
                     http.HTTPStatus.BAD_REQUEST, "Request on_save callback is not set."
                 )

--- a/tests/files/dev-config.yaml
+++ b/tests/files/dev-config.yaml
@@ -1,0 +1,5 @@
+host: jsonplaceholder.typicode.com
+scheme: https
+port: 443
+target_vm: compost
+dev: True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,7 @@ class TestConfig(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             config.read_conf('tests/files/missing-target-vm.yaml', self.p)
+
+    def test_dev_config(self):
+        c = config.read_conf('tests/files/dev-config.yaml', self.p)
+        self.assertTrue(c.dev)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,128 @@
+import contextlib
+import http
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest.mock
+
+import vcr
+from securedrop_proxy import entrypoint
+
+
+@contextlib.contextmanager
+def sdhome(*args, **kwds):
+    with tempfile.TemporaryDirectory() as tmphome:
+        os.environ["SECUREDROP_HOME"] = tmphome
+        try:
+            yield tmphome
+        finally:
+            del os.environ["SECUREDROP_HOME"]
+
+
+class TestEntrypoint(unittest.TestCase):
+    """
+    Test the entrypoint used in production.
+    """
+
+    def test_missing_config(self):
+        config_path = "/tmp/nonexistent-config.yaml"
+        self.assertFalse(os.path.exists(config_path))
+
+        output = None
+        with unittest.mock.patch(
+            "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
+        ) as mock_argv, unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(SystemExit), sdhome():
+                entrypoint.start()
+            output = mock_stdout.getvalue()
+
+        response = json.loads(output)
+        self.assertEqual(response["status"], http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        body = json.loads(response["body"])
+        self.assertEqual(
+            body["error"], "Configuration file does not exist at {}".format(config_path)
+        )
+
+    def test_unwritable_log_folder(self):
+        """
+        Tests a permission problem in `configure_logging`.
+        """
+        output = None
+        with sdhome() as home:
+            os.chmod(home, 0o0444)
+            with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                with self.assertRaises(SystemExit):
+                    entrypoint.start()
+                output = mock_stdout.getvalue()
+            os.chmod(home, 0o0700)
+
+        response = json.loads(output)
+        self.assertEqual(response["status"], http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        body = json.loads(response["body"])
+        self.assertIn("Permission denied: ", body["error"])
+
+    def test_wrong_number_of_arguments(self):
+        with sdhome() as home:
+            with unittest.mock.patch(
+                "sys.argv", new_callable=lambda: ["sd-proxy"]
+            ) as mock_argv, unittest.mock.patch(
+                "sys.stdout", new_callable=io.StringIO
+            ) as mock_stdout:
+                with self.assertRaises(SystemExit):
+                    entrypoint.start()
+                output = mock_stdout.getvalue()
+
+        response = json.loads(output)
+        self.assertEqual(response["status"], http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        body = json.loads(response["body"])
+        self.assertEqual(
+            body["error"], "sd-proxy script not called with path to configuration file"
+        )
+
+    def test_empty_input(self):
+        config_path = "tests/files/valid-config.yaml"
+        self.assertTrue(os.path.exists(config_path))
+
+        with sdhome() as home:
+            with unittest.mock.patch(
+                "sys.stdin", new_callable=lambda: io.StringIO("")
+            ) as mock_stdin, unittest.mock.patch(
+                "sys.stdout", new_callable=io.StringIO
+            ) as mock_stdout, unittest.mock.patch(
+                "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
+            ) as mock_argv:
+                entrypoint.start()
+                output = mock_stdout.getvalue()
+
+        response = json.loads(output)
+        self.assertEqual(response["status"], http.HTTPStatus.BAD_REQUEST)
+        body = json.loads(response["body"])
+        self.assertEqual(
+            body["error"], "Invalid JSON in request"
+        )
+
+    @vcr.use_cassette("fixtures/main_json_response.yaml")
+    def test_json_response(self):
+        config_path = "tests/files/valid-config.yaml"
+        self.assertTrue(os.path.exists(config_path))
+
+        test_input = {
+            "method": "GET",
+            "path_query": "/posts?userId=1",
+        }
+
+        output = None
+        with sdhome() as home, unittest.mock.patch(
+            "sys.stdin", new_callable=lambda: io.StringIO(json.dumps(test_input))
+        ) as mock_stding, unittest.mock.patch(
+            "sys.stdout", new_callable=io.StringIO
+        ) as mock_stdout, unittest.mock.patch(
+            "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
+        ) as mock_argv:
+            entrypoint.start()
+            output = mock_stdout.getvalue()
+
+        response = json.loads(output)
+        self.assertEqual(response["status"], http.HTTPStatus.OK)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -3,7 +3,6 @@ import http
 import io
 import json
 import os
-import sys
 import tempfile
 import unittest.mock
 
@@ -33,7 +32,9 @@ class TestEntrypoint(unittest.TestCase):
         output = None
         with unittest.mock.patch(
             "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
-        ) as mock_argv, unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+        ) as mock_argv, unittest.mock.patch(  # noqa: F841
+            "sys.stdout", new_callable=io.StringIO
+        ) as mock_stdout:
             with self.assertRaises(SystemExit), sdhome():
                 entrypoint.start()
             output = mock_stdout.getvalue()
@@ -52,7 +53,9 @@ class TestEntrypoint(unittest.TestCase):
         output = None
         with sdhome() as home:
             os.chmod(home, 0o0444)
-            with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with unittest.mock.patch(
+                "sys.stdout", new_callable=io.StringIO
+            ) as mock_stdout:
                 with self.assertRaises(SystemExit):
                     entrypoint.start()
                 output = mock_stdout.getvalue()
@@ -64,10 +67,10 @@ class TestEntrypoint(unittest.TestCase):
         self.assertIn("Permission denied: ", body["error"])
 
     def test_wrong_number_of_arguments(self):
-        with sdhome() as home:
+        with sdhome() as home:  # noqa: F841
             with unittest.mock.patch(
                 "sys.argv", new_callable=lambda: ["sd-proxy"]
-            ) as mock_argv, unittest.mock.patch(
+            ) as mock_argv, unittest.mock.patch(  # noqa: F841
                 "sys.stdout", new_callable=io.StringIO
             ) as mock_stdout:
                 with self.assertRaises(SystemExit):
@@ -85,23 +88,21 @@ class TestEntrypoint(unittest.TestCase):
         config_path = "tests/files/valid-config.yaml"
         self.assertTrue(os.path.exists(config_path))
 
-        with sdhome() as home:
+        with sdhome() as home:  # noqa: F841
             with unittest.mock.patch(
                 "sys.stdin", new_callable=lambda: io.StringIO("")
-            ) as mock_stdin, unittest.mock.patch(
+            ) as mock_stdin, unittest.mock.patch(  # noqa: F841
                 "sys.stdout", new_callable=io.StringIO
             ) as mock_stdout, unittest.mock.patch(
                 "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
-            ) as mock_argv:
+            ) as mock_argv:  # noqa: F841
                 entrypoint.start()
                 output = mock_stdout.getvalue()
 
         response = json.loads(output)
         self.assertEqual(response["status"], http.HTTPStatus.BAD_REQUEST)
         body = json.loads(response["body"])
-        self.assertEqual(
-            body["error"], "Invalid JSON in request"
-        )
+        self.assertEqual(body["error"], "Invalid JSON in request")
 
     @vcr.use_cassette("fixtures/main_json_response.yaml")
     def test_json_response(self):
@@ -114,13 +115,13 @@ class TestEntrypoint(unittest.TestCase):
         }
 
         output = None
-        with sdhome() as home, unittest.mock.patch(
+        with sdhome() as home, unittest.mock.patch(  # noqa: F841
             "sys.stdin", new_callable=lambda: io.StringIO(json.dumps(test_input))
-        ) as mock_stding, unittest.mock.patch(
+        ) as mock_stding, unittest.mock.patch(  # noqa: F841
             "sys.stdout", new_callable=io.StringIO
         ) as mock_stdout, unittest.mock.patch(
             "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
-        ) as mock_argv:
+        ) as mock_argv:  # noqa: F841
             entrypoint.start()
             output = mock_stdout.getvalue()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,7 +124,7 @@ class TestMain(unittest.TestCase):
         with self.assertRaises(SystemExit):
             main.__main__(test_input_json, p)
 
-    @vcr.use_cassette('fixtures/main_json_response.yaml')
+    @vcr.use_cassette('fixtures/main_input_headers.yaml')
     def test_input_headers(self):
         test_input = {
             "method": "GET",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,20 +16,20 @@ from securedrop_proxy import proxy
 class TestMain(unittest.TestCase):
     def setUp(self):
         self.conf = config.Conf()
-        self.conf.host = 'jsonplaceholder.typicode.com'
-        self.conf.scheme = 'https'
+        self.conf.host = "jsonplaceholder.typicode.com"
+        self.conf.scheme = "https"
         self.conf.port = 443
         self.conf.dev = True
 
-    @vcr.use_cassette('fixtures/main_json_response.yaml')
+    @vcr.use_cassette("fixtures/main_json_response.yaml")
     def test_json_response(self):
         test_input_json = """{ "method": "GET",
                             "path_query": "/posts?userId=1" }"""
 
         req = proxy.Req()
-        req.method = 'GET'
-        req.path_query = ''
-        req.headers = {'Accept': 'application/json'}
+        req.method = "GET"
+        req.path_query = ""
+        req.headers = {"Accept": "application/json"}
 
         # Use custom callbacks
         def on_save(res, fh, conf):
@@ -51,10 +51,10 @@ class TestMain(unittest.TestCase):
             sys.stdout = saved_stdout
 
         response = json.loads(output)
-        for item in json.loads(response['body']):
-            self.assertEqual(item['userId'], 1)
+        for item in json.loads(response["body"]):
+            self.assertEqual(item["userId"], 1)
 
-    @vcr.use_cassette('fixtures/main_non_json_response.yaml')
+    @vcr.use_cassette("fixtures/main_non_json_response.yaml")
     def test_non_json_response(self):
         test_input_json = """{ "method": "GET",
                                "path_query": "" }"""
@@ -64,9 +64,9 @@ class TestMain(unittest.TestCase):
 
             subprocess.run(["cp", fh.name, "/tmp/{}".format(self.fn)])
 
-            res.headers['X-Origin-Content-Type'] = res.headers['Content-Type']
-            res.headers['Content-Type'] = 'application/json'
-            res.body = json.dumps({'filename': self.fn})
+            res.headers["X-Origin-Content-Type"] = res.headers["Content-Type"]
+            res.headers["Content-Type"] = "application/json"
+            res.body = json.dumps({"filename": self.fn})
 
         self.p = proxy.Proxy(self.conf, proxy.Req(), on_save)
 
@@ -80,10 +80,10 @@ class TestMain(unittest.TestCase):
             sys.stdout = saved_stdout
 
         response = json.loads(output)
-        self.assertEqual(response['status'], 200)
+        self.assertEqual(response["status"], 200)
 
         # The proxy should have created a filename in the response body
-        self.assertIn('filename', response['body'])
+        self.assertIn("filename", response["body"])
 
         # The file should not be empty
         with open("/tmp/{}".format(self.fn)) as f:
@@ -100,7 +100,7 @@ class TestMain(unittest.TestCase):
 
         def on_done(res):
             res = res.__dict__
-            self.assertEqual(res['status'], 400)
+            self.assertEqual(res["status"], 400)
             sys.exit(1)
 
         p = proxy.Proxy(self.conf, proxy.Req(), on_save, on_done)
@@ -116,20 +116,20 @@ class TestMain(unittest.TestCase):
 
         def on_done(res):
             res = res.__dict__
-            self.assertEqual(res['status'], 400)
-            self.assertEqual(res['body'], '{"error": "Missing keys in request"}')
+            self.assertEqual(res["status"], 400)
+            self.assertEqual(res["body"], '{"error": "Missing keys in request"}')
             sys.exit(1)
 
         p = proxy.Proxy(self.conf, proxy.Req(), on_save, on_done)
         with self.assertRaises(SystemExit):
             main.__main__(test_input_json, p)
 
-    @vcr.use_cassette('fixtures/main_input_headers.yaml')
+    @vcr.use_cassette("fixtures/main_input_headers.yaml")
     def test_input_headers(self):
         test_input = {
             "method": "GET",
             "path_query": "/posts?userId=1",
-            "headers": { "X-Test-Header": "th" }
+            "headers": {"X-Test-Header": "th"},
         }
 
         def on_save(fh, res, conf):
@@ -139,12 +139,12 @@ class TestMain(unittest.TestCase):
         main.__main__(json.dumps(test_input), p)
         self.assertEqual(p.req.headers, test_input["headers"])
 
-    @vcr.use_cassette('fixtures/main_input_body.yaml')
+    @vcr.use_cassette("fixtures/main_input_body.yaml")
     def test_input_body(self):
         test_input = {
             "method": "POST",
             "path_query": "/posts",
-            "body": { "id": 42, "title": "test" }
+            "body": {"id": 42, "title": "test"},
         }
 
         def on_save(fh, res, conf):
@@ -154,7 +154,7 @@ class TestMain(unittest.TestCase):
         main.__main__(json.dumps(test_input), p)
         self.assertEqual(p.req.body, test_input["body"])
 
-    @vcr.use_cassette('fixtures/main_non_json_response.yaml')
+    @vcr.use_cassette("fixtures/main_non_json_response.yaml")
     def test_default_callbacks(self):
         test_input = {
             "method": "GET",
@@ -162,7 +162,11 @@ class TestMain(unittest.TestCase):
         }
 
         p = proxy.Proxy(self.conf, proxy.Req())
-        with unittest.mock.patch("securedrop_proxy.callbacks.on_done") as on_done, unittest.mock.patch("securedrop_proxy.callbacks.on_save") as on_save:
+        with unittest.mock.patch(
+            "securedrop_proxy.callbacks.on_done"
+        ) as on_done, unittest.mock.patch(
+            "securedrop_proxy.callbacks.on_save"
+        ) as on_save:
             main.__main__(json.dumps(test_input), p)
             self.assertEqual(on_save.call_count, 1)
             self.assertEqual(on_done.call_count, 1)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,8 +1,12 @@
+import http
 import json
-import vcr
 import unittest
 import uuid
 
+import requests
+import vcr
+
+from securedrop_proxy import callbacks
 from securedrop_proxy import proxy
 from securedrop_proxy import config
 from securedrop_proxy import version
@@ -136,7 +140,7 @@ class TestProxyValidConfig(unittest.TestCase):
 
         self.assertEqual(p.res.status, 400)
         self.assertEqual(p.res.headers['Content-Type'], 'application/json')
-        self.assertIn('Request callback is not set',
+        self.assertIn('Request on_save callback is not set',
                       p.res.body)
 
 
@@ -167,3 +171,127 @@ class TestProxyInvalidConfig(unittest.TestCase):
         self.assertEqual(p.res.headers['Content-Type'], 'application/json')
         self.assertIn('Proxy error while generating URL to request',
                       p.res.body)
+
+
+class TestServerErrorHandling(unittest.TestCase):
+    def setUp(self):
+        self.conf = config.Conf()
+        self.conf.host = "localhost"
+        self.conf.scheme = "http"
+        self.conf.port = 8000
+
+    def make_request(self, method="GET", path_query="/", headers=None):
+        req = proxy.Req()
+        req.method = method if method else "GET"
+        req.path_query = path_query if path_query else "/"
+        req.headers = headers if headers else {"Accept": "application/json"}
+        return req
+
+    def test_cannot_connect(self):
+        """
+        Test for "502 Bad Gateway" when the server can't be reached.
+        """
+        req = self.make_request()
+
+        conf = config.Conf()
+        conf.host = "sdproxytest.local"
+        conf.scheme = "https"
+        conf.port = 8000
+
+        p = proxy.Proxy(conf, req, on_save=callbacks.on_save)
+        p.proxy()
+
+        self.assertEqual(p.res.status, http.HTTPStatus.BAD_GATEWAY)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(body["error"], "could not connect to server")
+
+    def test_server_timeout(self):
+        """
+        Test for "504 Gateway Timeout" when the server times out.
+        """
+        class TimeoutProxy(proxy.Proxy):
+            """
+            Mocks a slow upstream server.
+
+            VCR cassettes cannot represent a request that takes too
+            long. This Proxy subclass raises the exception that would
+            cause.
+            """
+            def prep_request(self):
+                raise requests.exceptions.Timeout('test timeout')
+
+        req = self.make_request(path_query="/tarpit")
+        p = TimeoutProxy(self.conf, req, on_save=callbacks.on_save, timeout=0.00001)
+        p.proxy()
+
+        self.assertEqual(p.res.status, http.HTTPStatus.GATEWAY_TIMEOUT)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(body["error"], "request timed out")
+
+    @vcr.use_cassette("fixtures/proxy_bad_request.yaml")
+    def test_bad_request(self):
+        """
+        Test handling of "400 Bad Request" from the server.
+        """
+        req = self.make_request(path_query="/bad")
+        p = proxy.Proxy(self.conf, req, on_save=callbacks.on_save)
+        p.proxy()
+
+        self.assertEqual(p.res.status, http.HTTPStatus.BAD_REQUEST)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(body["error"], http.HTTPStatus.BAD_REQUEST.phrase.lower())
+
+    @vcr.use_cassette("fixtures/proxy_unofficial_status.yaml")
+    def test_unofficial_status(self):
+        """
+        Make sure we handle unofficial status codes from the server.
+
+        Should the server ever need to return a status code not in
+        Python's http.HTTPStatus, the proxy should still return a
+        proper JSON error response with a generic error message.
+        """
+        req = self.make_request(path_query="/teapot")
+        p = proxy.Proxy(self.conf, req, on_save=callbacks.on_save)
+        p.proxy()
+
+        self.assertEqual(p.res.status, 418)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(body["error"], "unspecified server error")
+
+    @vcr.use_cassette("fixtures/proxy_internal_server_error.yaml")
+    def test_internal_server_error(self):
+        """
+        Test handling of "500 Internal Server Error" from the server.
+        """
+        req = self.make_request(path_query="/crash")
+        p = proxy.Proxy(self.conf, req, on_save=callbacks.on_save)
+        p.proxy()
+
+        self.assertEqual(p.res.status, http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(
+            body["error"],
+            http.HTTPStatus.INTERNAL_SERVER_ERROR.phrase.lower()
+        )
+
+    @vcr.use_cassette("fixtures/proxy_internal_error.yaml")
+    def test_internal_error(self):
+        """
+        Ensure that the proxy returns JSON despite internal errors.
+        """
+        def bad_on_save(self, fh, res, conf):
+            raise Exception("test internal proxy error")
+
+        req = self.make_request()
+        p = proxy.Proxy(self.conf, req, on_save=bad_on_save)
+        p.proxy()
+
+        self.assertEqual(p.res.status, http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("application/json", p.res.headers["Content-Type"])
+        body = json.loads(p.res.body)
+        self.assertEqual(body["error"], "internal proxy error")


### PR DESCRIPTION
## Description

Try to ensure the proxy always returns a valid JSON response. Add specific handling of upstream error responses to proxy.py, and add tests and fixtures for that.

Replace the Proxy._on_done static method with an instance method.

In main.py, bail out upon receiving invalid input JSON, instead of printing an error response and then continuing to try to use it, resulting in printing another error response.

Have main.py use the callbacks on the proxy as given, instead of always overwriting them with the defaults from callbacks.py.

Rework entrypoint.py so that it should always print a JSON response, and add tests for it.

Fixes #13.

## Testing

1. Build the `securedrop-proxy` source distribution:
    - check out this branch
    - run `python setup.py sdist`
2. Build the `.deb`:
    - in a clone of `securedrop-debian-packaging`, run `PKG_PATH=/home/user/src/securedrop-proxy/dist/securedrop-proxy-0.1.6.tar.gz PKG_VERSION=0.1.6 make securedrop-proxy` (adjust the path to your working copy of this repo as necessary)
3. Install the `.deb` in `sd-svs-buster-template`:
    - `qvm-copy ~/debbuild/packaging/securedrop-proxy_0.1.6+buster_all.deb` and specify `sd-svs-buster-template` as the target VM
    - In a shell on `sd-svs-buster-template`, run:
        - `cp ~/QubesIncoming/sd-dev/securedrop-proxy_0.1.6+buster_all.deb /tmp`
        - `sudo apt install /tmp/securedrop-proxy_0.1.6+buster_all.deb`
4. Reboot.
5. Start the SecureDrop client in `sd-svs` and confirm that the proxy is communicating with the server: submissions and replies should populate with no errors.