### PR TITLE
Adds logging to /var/log/syslog using rsyslog

### DIFF
--- a/securedrop_proxy/entrypoint.py
+++ b/securedrop_proxy/entrypoint.py
@@ -11,8 +11,9 @@ import json
 import logging
 import os
 import sys
+import platform
 
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import TimedRotatingFileHandler, SysLogHandler
 
 from securedrop_proxy import main
 from securedrop_proxy import proxy
@@ -83,7 +84,19 @@ def configure_logging() -> None:
     handler.setFormatter(formatter)
     handler.setLevel(logging.DEBUG)
 
+    # For rsyslog handler
+    if platform.system() != "Linux":  # pragma: no cover
+        syslog_file = "/var/run/syslog"
+    else:
+        syslog_file = "/dev/log"
+
+    sysloghandler = SysLogHandler(address=syslog_file)
+    sysloghandler.setFormatter(formatter)
+
     # set up primary log
     log = logging.getLogger()
     log.setLevel(LOGLEVEL)
     log.addHandler(handler)
+
+    # add the secondard logger
+    log.addHandler(sysloghandler)


### PR DESCRIPTION
Uses `rsyslog` to push to `/var/log/syslog` all log lines.

## How to test?

- [ ] Build the deb package from this branch
- [ ] Install it to the `sd-proxy` vm in Qubes
- [ ] Use the client in normal way
- [ ] Log lines should be found the in `/var/log/syslog` file on the `sd-proxy` vm and also on `~/logs/proxy.log` file.