### PR TITLE
Fixes CI for git-lfs based package builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,10 @@ common-steps:
       name: Install Debian packaging dependencies and download wheels
       command: |
         mkdir ~/packaging && cd ~/packaging
+        git config --global --unset url.ssh://git@github.com.insteadof
         git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
         cd securedrop-debian-packaging
-        make install-deps && make fetch-wheels
+        make install-deps
         PKG_DIR=~/project make requirements
 
   - &verify_requirements


### PR DESCRIPTION
Follows https://github.com/freedomofpress/securedrop-client/pull/699 and updates the CI to use the LFS repo for Debian packaging.