### PR TITLE
Uses incoming timeout value from JSON

### DIFF
--- a/securedrop_proxy/main.py
+++ b/securedrop_proxy/main.py
@@ -42,4 +42,7 @@ def __main__(incoming: str, p: Proxy) -> None:
 
     p.req = req
 
+    if "timeout" in client_req:
+        p.timeout = client_req["timeout"]
+
     p.proxy()


### PR DESCRIPTION
Fixes #68

Now we are using the incoming timeout value from the JSON input.

## How to test?

- [x] `make check` passes
- [ ] CI is green
- [x] Do a visual check

Part of solving https://github.com/freedomofpress/securedrop-client/issues/1007 