### PR TITLE
Moves config to private volume

### DIFF
--- a/qubes/securedrop.Proxy
+++ b/qubes/securedrop.Proxy
@@ -1,1 +1,1 @@
-/usr/bin/sd-proxy /etc/sd-proxy.yaml
+/usr/bin/sd-proxy /home/user/.securedrop_proxy/sd-proxy.yaml


### PR DESCRIPTION
The Qubes RPC file hardcodes the filepath to the YAML config file, which contains site-specific information such as the Onion URL for the Journalist Interface. As part of template consolidation [0], we're moving the config file out of the system/root partition and into the private (i.e. /home/) volume, so that the `sd-proxy` AppVM has the config information it needs while sharing a TemplateVM with other components.

[0] https://github.com/freedomofpress/securedrop-workstation/issues/471

Closes #77. 

## Testing

A new package has been built based on this change and uploaded to apt-test via https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/65. You can check out the Workstation branch for https://github.com/freedomofpress/securedrop-workstation/pull/619 to evaluate how the new package operates in tandem with the modified salt logic to ensure that the proxy config exists only in the private volume for `sd-proxy`. 