### PR TITLE
Add link to Code of Conduct to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md).
+
 ## securedrop workstation proxy
 
 [![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-proxy.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-proxy)


### PR DESCRIPTION
## Status
Ready for review
## Description
Part of efforts to centralize Code of Conduct management for FPF open source repos. See:
- https://github.com/freedomofpress/.github/pull/1
- https://github.com/freedomofpress/securedrop/pull/5889