### PR TITLE
Fix unofficial_status test on Python 3.9+

### DIFF
--- a/fixtures/proxy_unofficial_status.yaml
+++ b/fixtures/proxy_unofficial_status.yaml
@@ -15,6 +15,6 @@ interactions:
       Server:
       - BaseHTTP/0.6 Python/3.7.3
     status:
-      code: 418
+      code: 499
       message: ''
 version: 1

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -227,7 +227,7 @@ class TestServerErrorHandling(unittest.TestCase):
         p = proxy.Proxy(self.conf_path, req)
         p.proxy()
 
-        self.assertEqual(p.res.status, 418)
+        self.assertEqual(p.res.status, 499)
         self.assertIn("application/json", p.res.headers["Content-Type"])
         body = json.loads(p.res.body)
         self.assertEqual(body["error"], "unspecified server error")


### PR DESCRIPTION
## Status

Ready for review

## Description

HTTP 418 was added to http.HTTPStatus in Python 3.9, so it no longer
fails with "unspecified server error".

Use status code 499 as something that should never really be added
in the near future.

## Test plan
With Python 3.9 (e.g. Fedora 34), run `make test` and observe it now passes with this change.