### PR TITLE
Reject JSON with duplicate keys

### DIFF
--- a/securedrop_proxy/entrypoint.py
+++ b/securedrop_proxy/entrypoint.py
@@ -7,14 +7,13 @@
 # the README for configuration options.
 
 import http
-import json
 import logging
 import os
 import platform
 import sys
 from logging.handlers import SysLogHandler, TimedRotatingFileHandler
 
-from securedrop_proxy import main, proxy
+from securedrop_proxy import json, main, proxy
 from securedrop_proxy.version import version
 
 DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".securedrop_proxy")

--- a/securedrop_proxy/json.py
+++ b/securedrop_proxy/json.py
@@ -1,0 +1,24 @@
+"""
+Wrapper around Python's json to catch duplicate keys (potential JSON injection)
+
+This was informational finding TOB-SDW-014 in the 2020 audit.
+"""
+import json
+
+dumps = json.dumps
+
+
+def _check(seq):
+    d = {}
+    for key, value in seq:
+        if key in d:
+            raise ValueError(f"Key '{key}' found twice in JSON object")
+        d[key] = value
+    return d
+
+
+def loads(text: str) -> dict:
+    """
+    Turn a string into a JSON object, but reject duplicate keys
+    """
+    return json.loads(text, object_pairs_hook=_check)

--- a/securedrop_proxy/main.py
+++ b/securedrop_proxy/main.py
@@ -1,8 +1,7 @@
-import json
 import logging
 from typing import Any, Dict
 
-from securedrop_proxy import proxy
+from securedrop_proxy import json, proxy
 from securedrop_proxy.proxy import Proxy
 
 logger = logging.getLogger(__name__)
@@ -17,7 +16,7 @@ def __main__(incoming: str, p: Proxy) -> None:
     client_req: Dict[str, Any] = {}
     try:
         client_req = json.loads(incoming)
-    except json.decoder.JSONDecodeError as e:
+    except ValueError as e:
         logging.error(e)
         p.simple_error(400, "Invalid JSON in request")
         p.on_done()

--- a/securedrop_proxy/proxy.py
+++ b/securedrop_proxy/proxy.py
@@ -1,5 +1,4 @@
 import http
-import json
 import logging
 import os
 import subprocess
@@ -14,6 +13,7 @@ import werkzeug
 import yaml
 
 import securedrop_proxy.version as version
+from securedrop_proxy import json
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,21 @@
+import unittest
+
+from securedrop_proxy import json
+
+
+class JsonTest(unittest.TestCase):
+    def test_dumps(self):
+        """Simple check since this is a passthrough to stdlib json"""
+        self.assertEqual(
+            json.dumps({"foo": "bar", "baz": ["one"]}), '{"foo": "bar", "baz": ["one"]}'
+        )
+
+    def test_loads(self):
+        # Verify basic loading works
+        self.assertEqual(
+            json.loads('{"foo": "bar", "baz": ["one"]}'), {"foo": "bar", "baz": ["one"]}
+        )
+        # But duplicate keys are rejected
+        with self.assertRaises(ValueError) as exc:
+            json.loads('{"foo": "bar", "foo": "baz"}')
+        self.assertEqual(str(exc.exception), "Key 'foo' found twice in JSON object")


### PR DESCRIPTION
## Status

Ready for review

## Description

Informational finding TOB-SDW-014 from the 2020 SecureDrop Workstation audit
recommended explicitly checking for and rejecting duplicate JSON keys to
prevent against JSON injection attacks.

The new "json" module is a drop-in replacement for the current usage of
the standard library's JSON module, except using `loads()` will throw
an exception on duplicate keys.

Callers should now catch any ValueErrors, which also covers JSONDecodeError.

Fixes #84.

## Test plan
```
$ echo '{"method":"GET", "method":"POST"}' | sd-proxy config-example.yaml
{"status": 400, "body": "{\"error\": \"Invalid JSON in request\"}", "headers": {"Content-Type": "application/json"}, "version": "0.3.1\n"}
```