### PR TITLE
Use plain Debian containers for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,10 @@
 ---
 common-steps:
-  - &removevirtualenv
-    run:
-      name: Removes the upstream virtualenv from the original container image
-      command: sudo pip uninstall virtualenv -y
-
   - &run_tests
     run:
       name: Install requirements and run tests
       command: |
+        apt-get update && apt-get install -y make python3-venv
         make venv
         source .venv/bin/activate
         make check
@@ -17,8 +13,8 @@ common-steps:
     run:
       name: Install Debian packaging dependencies and download wheels
       command: |
+        apt-get update && apt-get install -y git git-lfs make sudo
         mkdir ~/packaging && cd ~/packaging
-        git config --global --unset url.ssh://git@github.com.insteadof
         git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
         cd securedrop-debian-packaging
         make install-deps
@@ -47,17 +43,16 @@ common-steps:
       command: |
         cd ~/packaging/securedrop-debian-packaging
         export PKG_VERSION=1000.0
-        export PKG_PATH=/home/circleci/project/dist/securedrop-proxy-$PKG_VERSION.tar.gz
+        export PKG_PATH=~/project
         make securedrop-proxy
 
 version: 2
 jobs:
   build-bullseye:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: debian:bullseye
     steps:
       - checkout
-      - *removevirtualenv
       - *install_packaging_dependencies
       - *verify_requirements
       - *make_source_tarball
@@ -65,7 +60,7 @@ jobs:
 
   test-bullseye:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: debian:bullseye
     steps:
       - checkout
       - *run_tests

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -5,7 +5,7 @@ import json
 import os
 import platform
 import tempfile
-import unittest.mock
+import unittest
 from unittest.mock import patch
 
 import vcr
@@ -33,9 +33,9 @@ class TestEntrypoint(unittest.TestCase):
         self.assertFalse(os.path.exists(config_path))
 
         output = None
-        with unittest.mock.patch(
+        with patch(
             "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
-        ) as mock_argv, unittest.mock.patch(  # noqa: F841
+        ) as mock_argv, patch(  # noqa: F841
             "sys.stdout", new_callable=io.StringIO
         ) as mock_stdout:
             with self.assertRaises(SystemExit), sdhome():
@@ -72,7 +72,7 @@ class TestEntrypoint(unittest.TestCase):
         output = None
         with sdhome() as home:
             os.chmod(home, 0o0444)
-            with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
                 with self.assertRaises(SystemExit):
                     entrypoint.start()
                 output = mock_stdout.getvalue()
@@ -85,9 +85,9 @@ class TestEntrypoint(unittest.TestCase):
 
     def test_wrong_number_of_arguments(self):
         with sdhome() as home:  # noqa: F841
-            with unittest.mock.patch(
+            with patch(
                 "sys.argv", new_callable=lambda: ["sd-proxy"]
-            ) as mock_argv, unittest.mock.patch(  # noqa: F841
+            ) as mock_argv, patch(  # noqa: F841
                 "sys.stdout", new_callable=io.StringIO
             ) as mock_stdout:
                 with self.assertRaises(SystemExit):
@@ -106,11 +106,11 @@ class TestEntrypoint(unittest.TestCase):
         self.assertTrue(os.path.exists(config_path))
 
         with sdhome() as home:  # noqa: F841
-            with unittest.mock.patch(
+            with patch(
                 "sys.stdin", new_callable=lambda: io.StringIO("")
-            ) as mock_stdin, unittest.mock.patch(  # noqa: F841
+            ) as mock_stdin, patch(  # noqa: F841
                 "sys.stdout", new_callable=io.StringIO
-            ) as mock_stdout, unittest.mock.patch(
+            ) as mock_stdout, patch(
                 "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
             ) as mock_argv:  # noqa: F841
                 entrypoint.start()
@@ -132,11 +132,11 @@ class TestEntrypoint(unittest.TestCase):
         }
 
         output = None
-        with sdhome() as home, unittest.mock.patch(  # noqa: F841
+        with sdhome() as home, patch(  # noqa: F841
             "sys.stdin", new_callable=lambda: io.StringIO(json.dumps(test_input))
-        ) as mock_stding, unittest.mock.patch(  # noqa: F841
+        ) as mock_stding, patch(  # noqa: F841
             "sys.stdout", new_callable=io.StringIO
-        ) as mock_stdout, unittest.mock.patch(
+        ) as mock_stdout, patch(
             "sys.argv", new_callable=lambda: ["sd-proxy", config_path]
         ) as mock_argv:  # noqa: F841
             entrypoint.start()


### PR DESCRIPTION
Failing because the Debian containers default to root and one of the tests is trying to adjust permissions so it can't write to a folder, but that doesn't work because we're root now.