### PR TITLE
Configure dependabot for development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"


### PR DESCRIPTION
Production dependency updates are still manual because they need to go through securedrop-builder, but we can use dependabot for poetry dev dependency updates.

(CI is expected to fail on bookworm because of pyyaml issues)